### PR TITLE
Upgrade Guava to address CVE-2020-8908

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <!--Apache commons-io for IOUtils etc.-->


### PR DESCRIPTION
upgraded Guava from 29.0-jre -> 30.1.1-jre